### PR TITLE
fix: 名称統一

### DIFF
--- a/src/components/VitualPointer/VirtualPointer.tsx
+++ b/src/components/VitualPointer/VirtualPointer.tsx
@@ -1,21 +1,21 @@
 import React, { useRef, useEffect } from 'react';
-import { useKeyboardPointer } from './useKeyboardPointer';
+import { useVirtualPointer } from './useVirtualPointer';
 import { ensureCharRangeMap, updateCharRects   } from '../../utils/textMap';
 
 const pointerSize = 10;
 const margin = 20;
 
-const KeyboardPointer: React.FC = () => {
+const VirtualPointer: React.FC = () => {
   const pointerRef = useRef<HTMLDivElement>(null);
-  const { position, isFocusing, isCopyMode } = useKeyboardPointer({ pointerSize, margin });
+  const { position, isFocusing, isCopyMode } = useVirtualPointer({ pointerSize, margin });
   /**   現状は必要ない（現在の設計では使ってない）が、
    * 仮想ポインタの div 要素に ref（pointerRef）を利用するケースは以下の2つが考えられる:
    * 1.フックのrefからVirturePointerのref（pointerRef）に返す場合
    * 2.VirturePointerのref（pointerRef）フックに渡す場合
    */
   /**   必要になった場合は以下のようにそれぞれ対応してください:
-   * 1.返す場合は、VirtualPointer側の記述をconst { position, isFocusing, isCopyMode, pointerRef } = useKeyboardPointer({ pointerSize, margin });のようにして、useKeyboardPointer の返り値に pointerRef を含める設計にする 
-   * 2.渡す場合は、（useKeyboardPointer({pointerSize, margin, pointerRef}) などのようにuseKeyboardPointer の引数として渡すように設計する 
+   * 1.返す場合は、VirtualPointer側の記述をconst { position, isFocusing, isCopyMode, pointerRef } = useVirtualPointer({ pointerSize, margin });のようにして、useVirtualPointer の返り値に pointerRef を含める設計にする 
+   * 2.渡す場合は、（useVirtualPointer({pointerSize, margin, pointerRef}) などのようにuseVirtualPointer の引数として渡すように設計する 
    */
 
   // 初回描画時やリサイズ時に位置をウィンドウ中央に初期化したい場合はここで処理
@@ -69,14 +69,14 @@ const KeyboardPointer: React.FC = () => {
   return (
     <div
       ref={pointerRef}
-      id="keyboard-pointer"
+      id="Virtual-pointer"
       style={{
         position: 'fixed',
         width: `${pointerSize}px`,
         height: `${pointerSize}px`,
         background: isCopyMode ? 'green' : isFocusing ? 'blue' : 'red',
         borderRadius: '50%',
-        zIndex: 9999,
+        zIndex: 20000,
         pointerEvents: 'none',
         left: `${position.x}px`,
         top: `${position.y}px`,
@@ -85,4 +85,4 @@ const KeyboardPointer: React.FC = () => {
   );
 };
 
-export default KeyboardPointer;
+export default VirtualPointer;

--- a/src/components/VitualPointer/index.ts
+++ b/src/components/VitualPointer/index.ts
@@ -1,3 +1,3 @@
-// src/components/KeyboardPointer/index.ts
-export { useKeyboardPointer } from './useKeyboardPointer';
-export type { PointerPosition } from '../../types/KeyboardPointer';
+// src/components/VirtualPointer/index.ts
+export { useVirtualPointer } from './useVirtualPointer';
+export type { PointerPosition } from '../../types/VirtualPointer';

--- a/src/components/VitualPointer/useCopySelection.ts
+++ b/src/components/VitualPointer/useCopySelection.ts
@@ -4,7 +4,7 @@ import {
   getCharRangeAtOffset,
   getCharRangeIndex,
 } from '../../utils/textMap'; // テキスト選択の管理をbodyのindexでやる方針に切り替えた
-//import type { PointerPosition } from '../../types/KeyboardPointer'; //現在は使っていない
+//import type { PointerPosition } from '../../types/VirtualPointer'; //現在は使っていない
 
 
 type UseCopySelectionReturn = {

--- a/src/components/VitualPointer/usePointerMovement.ts
+++ b/src/components/VitualPointer/usePointerMovement.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { dispatchMouseEvent } from '../../utils/domEvents';
-import type { PointerPosition } from '../../types/KeyboardPointer';
+import type { PointerPosition } from '../../types/VirtualPointer';
 
 /**
  * usePointerMovement: ポインタ移動ロジック

--- a/src/components/VitualPointer/useVirtualEvents.ts
+++ b/src/components/VitualPointer/useVirtualEvents.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import type { PointerPosition } from '../../types/KeyboardPointer';
+import type { PointerPosition } from '../../types/VirtualPointer';
 
 type Handlers = {
   // 座標系: clientX, clientY を計算するために position.x/y と pointerSize/2 が必要
@@ -16,7 +16,7 @@ type Handlers = {
 };
 
 /**
- * useKeyboardEvents: document-level の keydown 登録と各種ハンドラ呼び出し
+ * useVirtualEvents: document-level の keydown 登録と各種ハンドラ呼び出し
  * positionRef: 最新の position
  * pointerSize: ポインタの大きさ
  * 
@@ -30,7 +30,7 @@ type Handlers = {
  * - Alt+Space 右クリック
  * - h/j/k/l でカーソル移動
  */
-export function useKeyboardEvents(
+export function useVirtualEvents(
   positionRef: React.MutableRefObject<PointerPosition>,
   pointerSize: number,
   margin: number,

--- a/src/components/VitualPointer/useVirtualPointer.ts
+++ b/src/components/VitualPointer/useVirtualPointer.ts
@@ -1,24 +1,24 @@
 /// <reference types="chrome" />
 
 import { useRef, useState, useCallback } from 'react';
-import type { PointerPosition } from '../../types/KeyboardPointer';
+import type { PointerPosition } from '../../types/VirtualPointer';
 import { useCopySelection } from './useCopySelection';
 import { useFocusBehavior } from './useFocusBehavior';
 import { usePointerMovement } from './usePointerMovement';
-import { useKeyboardEvents } from './useKeyboardEvents';
+import { useVirtualEvents } from './useVirtualEvents';
 import { dispatchMouseEvent } from '../../utils/domEvents';
 
-type UseKeyboardPointerOptions = {
+type UseVirtualPointerOptions = {
   pointerSize: number;
   margin: number;
 };
 
 /**
- * useKeyboardPointer: 仮想ポインタの状態管理・キーボード操作統合フック
+ * useVirtualPointer: 仮想ポインタの状態管理・キーボード操作統合フック
  * - ポインタ位置、コピー選択モード、フォーカスモードの管理
  * - 各種キーボード操作に応じてポインタ移動、選択、クリック、ダブルクリック、右クリックなどを制御
  */
-export function useKeyboardPointer({ pointerSize, margin }: UseKeyboardPointerOptions) {
+export function useVirtualPointer({ pointerSize, margin }: UseVirtualPointerOptions) {
   // 1. position state & ref
   // 画面中央に初期配置
   const [position, setPosition] = useState<PointerPosition>({
@@ -182,7 +182,7 @@ export function useKeyboardPointer({ pointerSize, margin }: UseKeyboardPointerOp
   }, [move]);
 
   // 6. キーボードイベント登録
-  useKeyboardEvents(positionRef, pointerSize, margin, {
+  useVirtualEvents(positionRef, pointerSize, margin, {
     handleCopyToggle,
     handleCancel,
     handleCopyAdjust,

--- a/src/types/VirtualPointer.ts
+++ b/src/types/VirtualPointer.ts
@@ -3,14 +3,14 @@ export type PointerPosition = {
     y: number; // pointerのY座標
 }
 
-export type KeyboardState = {
+export type VirtualState = {
     mode: 'idle' | 'focus' | 'copy'; // 現在のモード
     position: PointerPosition; // 現在のポインタ位置
     anchorNode: Text | null; // 選択範囲のアンカーノード
     anchorOffset: number; // 選択範囲のアンカーオフセット
 };
 
-export type KeyboardPointerActions = 
+export type VirtualPointerActions = 
     | { type: 'INIT_MOVE'; position: PointerPosition } // 初期位置設定
     | { type: 'START_COPY'; node: Text; offset: number; rect: DOMRect } // コピー選択開始
     | { type: 'ADJUST_COPY'; node: Text; offset: number; rect: DOMRect } // コピー選択調整


### PR DESCRIPTION
- 今までKeyboardPointer, VirtualPointerの二つの呼称が混じっていたのを、VirtualPointerに統一した。