### PR TITLE
chatGPTの検索欄など初めからフォーカスが当たっている場合のフォーカス動作の改善

### DIFF
--- a/src/components/VitualPointer/VirtualPointer.tsx
+++ b/src/components/VitualPointer/VirtualPointer.tsx
@@ -7,7 +7,7 @@ const margin = 20;
 
 const VirtualPointer: React.FC = () => {
   const pointerRef = useRef<HTMLDivElement>(null);
-  const { position, isFocusing, isCopyMode } = useVirtualPointer({ pointerSize, margin });
+  const { position, isFocusing, isCopyMode, startFocus } = useVirtualPointer({ pointerSize, margin });
   /**   現状は必要ない（現在の設計では使ってない）が、
    * 仮想ポインタの div 要素に ref（pointerRef）を利用するケースは以下の2つが考えられる:
    * 1.フックのrefからVirturePointerのref（pointerRef）に返す場合
@@ -17,6 +17,7 @@ const VirtualPointer: React.FC = () => {
    * 1.返す場合は、VirtualPointer側の記述をconst { position, isFocusing, isCopyMode, pointerRef } = useVirtualPointer({ pointerSize, margin });のようにして、useVirtualPointer の返り値に pointerRef を含める設計にする 
    * 2.渡す場合は、（useVirtualPointer({pointerSize, margin, pointerRef}) などのようにuseVirtualPointer の引数として渡すように設計する 
    */
+
 
   // 初回描画時やリサイズ時に位置をウィンドウ中央に初期化したい場合はここで処理
   useEffect(() => {
@@ -63,7 +64,14 @@ const VirtualPointer: React.FC = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-
+  
+  useEffect(() => {
+    const active = document.activeElement;
+    if (active && ['INPUT', 'TEXTAREA', 'SELECT'].includes(active.tagName)) {
+      // useFocusBehavior の startFocus を呼び出す形で状態をセットする
+      startFocus(active);
+    }
+  }, []);
   
 
   return (

--- a/src/components/VitualPointer/useFocusBehavior.ts
+++ b/src/components/VitualPointer/useFocusBehavior.ts
@@ -16,18 +16,22 @@ export function useFocusBehavior() {
    * 指定した要素にフォーカスをセットし、状態を管理
    * フォーカス中は仮想ポインタの色を変えるなどのUI反映を想定
    */
-  const startFocus = useCallback((target: Element) => {
-    if (
-      ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) &&
-      target instanceof HTMLElement &&
-      typeof target.focus === 'function' &&
-      !target.hasAttribute('disabled')
-    ) {
-      target.focus({ preventScroll: true });
-      isFocusingRef.current = true;
-      setIsFocusing(true);
-    }
-  }, []);
+const startFocus = useCallback((target: Element) => {
+  if (
+    target instanceof HTMLElement &&
+    (
+      ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) ||
+      target.isContentEditable
+    ) &&
+    typeof target.focus === 'function' &&
+    !target.hasAttribute('disabled')
+  ) {
+    target.focus({ preventScroll: true });
+    isFocusingRef.current = true;
+    setIsFocusing(true);
+  }
+}, []);
+
 
   /**
    * フォーカス状態を解除し、状態をリセットする

--- a/src/components/VitualPointer/useVirtualPointer.ts
+++ b/src/components/VitualPointer/useVirtualPointer.ts
@@ -133,17 +133,34 @@ export function useVirtualPointer({ pointerSize, margin }: UseVirtualPointerOpti
    * Ctrl+Space でのクリック + フォーカス処理
    * 仮想ポインタ位置でマウスイベントを発火し、フォーカス可能ならフォーカス開始
    */
-  const handleClickFocus = useCallback((clientX: number, clientY: number) => {
-    // クリック発行
-    (['mousedown', 'mouseup', 'click'] as const).forEach((type) => {
-      dispatchMouseEvent(type, clientX, clientY);
-    });
-    // フォーカス
-    const target = document.elementFromPoint(clientX, clientY);
-    if (target) {
-      startFocus(target);
-    }
-  }, [startFocus]);
+const handleClickFocus = useCallback((clientX: number, clientY: number) => {
+  // クリックイベントを発行
+  console.log('handleClickFocus:', clientX, clientY);
+  (['mousedown', 'mouseup', 'click'] as const).forEach((type) => {
+    dispatchMouseEvent(type, clientX, clientY);
+  });
+
+  // elementFromPointで要素を取得
+  const target = document.elementFromPoint(clientX, clientY);
+  console.log('elementFromPoint:', target);
+
+  if (!target || !(target instanceof HTMLElement)) return;
+
+  // 最も近い入力可能な要素を親方向にたどる
+  // ここで「近い入力可能な要素」とは、自身か親要素で textarea, input, contenteditable="true" のいずれかに該当するものを意味する
+  // クリックが placeholder や子要素に当たっても、親の入力可能な要素を取得するために使う
+  const focusable = target.closest('textarea, input, [contenteditable="true"]');
+
+  if (focusable instanceof HTMLElement) {
+    console.log('found focusable element via closest:', focusable);
+    // 見つかった入力要素にフォーカスをセット
+    startFocus(focusable);
+  } else {
+    console.log('no focusable element found');
+  }
+}, [startFocus]);
+
+
 
   /**
    * Ctrl+Alt+Space でのダブルクリック処理
@@ -203,5 +220,6 @@ export function useVirtualPointer({ pointerSize, margin }: UseVirtualPointerOpti
     getPointerRef: () => {//外部から pointerRef にアクセスさせたい場合に使う関数
       return null;
     },
+    startFocus,
   };
 }


### PR DESCRIPTION
chatGPTの検索欄など初めからフォーカスが当たっている場合のフォーカス動作を改善した。
githubの検索欄など画面遷移が若干入るタイプのものは動作がまだおかしいが、2回クリックすればフォーカスモードに移行されるため見なかったことにした。
