### PR TITLE
コピーモード時のCtrl+A全文選択機能を追加しました。

### DIFF
--- a/src/components/VitualPointer/useCopySelection.ts
+++ b/src/components/VitualPointer/useCopySelection.ts
@@ -3,6 +3,7 @@ import {
   getNearestCharRange,
   getCharRangeAtOffset,
   getCharRangeIndex,
+  getCharRangeLength,
 } from '../../utils/textMap'; // テキスト選択の管理をbodyのindexでやる方針に切り替えた
 //import type { PointerPosition } from '../../types/VirtualPointer'; //現在は使っていない
 
@@ -14,6 +15,7 @@ type UseCopySelectionReturn = {
     direction: 'left' | 'right',
     onUpdate: (pos: { x: number; y: number }) => void
   ) => void;
+  selectAll: () => void;
   cancelCopy: () => void;
 };
 
@@ -109,6 +111,27 @@ export function useCopySelection(): UseCopySelectionReturn {
     onUpdate({ x: rect.left, y: rect.bottom });
   };
 
+  const selectAll = () => {
+    const totalCount = getCharRangeLength();
+    if (totalCount === 0) return;
+
+    const firstChar = getCharRangeAtOffset(0);
+    const lastChar = getCharRangeAtOffset(totalCount - 1);
+
+    if (!firstChar || !lastChar) return;
+
+    const range = document.createRange();
+    range.setStart(firstChar.range.startContainer, firstChar.range.startOffset);
+    range.setEnd(lastChar.range.endContainer, lastChar.range.endOffset);
+
+    const selection = window.getSelection();
+    if (selection) {
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+  };
+
+
   /**
    * コピー選択解除 (Escape)
    * 選択範囲をクリアし、状態をリセットする
@@ -126,6 +149,7 @@ export function useCopySelection(): UseCopySelectionReturn {
     isCopyMode,
     startCopy,
     adjustCopy,
+    selectAll,
     cancelCopy,
   };
 }

--- a/src/components/VitualPointer/useVirtualEvents.ts
+++ b/src/components/VitualPointer/useVirtualEvents.ts
@@ -6,6 +6,7 @@ type Handlers = {
   handleCopyToggle: (clientX: number, clientY: number) => void;
   handleCancel: () => void;
   handleCopyAdjust: (direction: 'left' | 'right') => void;
+  handleSelectAll: () => void;
   isCopyMode: () => boolean;
   isFocusingRef: React.MutableRefObject<boolean>;
   handleScrollOrHistory: (key: string, stepY: number) => boolean;
@@ -60,11 +61,14 @@ export function useVirtualEvents(
       }
 
       // コピー選択モード中の範囲調整やコピー(Ctrl+C)
-      if (handlers.isCopyMode() && (e.key === 'h' || e.key === 'l' || (e.ctrlKey && e.key.toLowerCase() === 'c'))) {
+      if (handlers.isCopyMode() && (e.key === 'h' || e.key === 'l' || (e.ctrlKey && e.key.toLowerCase() === 'a') || (e.ctrlKey && e.key.toLowerCase() === 'c'))) {
         if (e.key === 'l') {
           handlers.handleCopyAdjust('right');
         } else if (e.key === 'h') {
           handlers.handleCopyAdjust('left');
+        }
+        if (e.ctrlKey && e.key.toLowerCase() === 'a') {
+          handlers.handleSelectAll();
         }
         if (e.ctrlKey && e.key.toLowerCase() === 'c') {
           document.execCommand('copy'); // クリップボードコピー実行

--- a/src/components/VitualPointer/useVirtualPointer.ts
+++ b/src/components/VitualPointer/useVirtualPointer.ts
@@ -37,6 +37,7 @@ export function useVirtualPointer({ pointerSize, margin }: UseVirtualPointerOpti
     isCopyMode,
     startCopy,
     adjustCopy,
+    selectAll,
     cancelCopy,
   } = useCopySelection();
 
@@ -83,6 +84,10 @@ export function useVirtualPointer({ pointerSize, margin }: UseVirtualPointerOpti
       updatePosition({ x: pos.x - pointerSize / 2, y: pos.y - pointerSize / 2 });
     });
   }, [adjustCopy, updatePosition, pointerSize]);
+
+  const handleSelectAll = useCallback(() => {
+    selectAll();
+  }, [selectAll]);
 
   /**
    * Alt+H/L/J/K キーでのページスクロールや履歴移動（Chrome拡張のメッセージ送信）
@@ -211,6 +216,7 @@ const handleClickFocus = useCallback((clientX: number, clientY: number) => {
     handleCopyToggle,
     handleCancel,
     handleCopyAdjust,
+    handleSelectAll,
     isCopyMode: () => isCopyMode,
     isFocusingRef,
     handleScrollOrHistory,

--- a/src/utils/textMap.ts
+++ b/src/utils/textMap.ts
@@ -117,3 +117,8 @@ export const getCharRangeIndex = (target: Range): number => {
   return -1; //該当の文字がなければ-1を返し、無いことを示す
   //-1を返すと、getCharRangeAtOffsetにおいてnullが返り、それを判定して処理を止める
 };
+
+/**
+ * charRangesの（全体の範囲に対する）インデックスの長さを返す
+ */
+export const getCharRangeLength = () => charRanges.length;


### PR DESCRIPTION
コピーモード時のCtrl+A全文選択機能を追加しました。
そもそもコピーモードじゃないときにCtrl+Aを押せば全文選択できることに気付いて無駄機能感はありますが、無いよりある方が良いと思うので…